### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to install mathjax-node-svg2png and its dependencies.
 
 This module is used like mathjax-node, extending the input `data` object with new options
 
-    png: false              // enable PNG generation
+    png: true               // enable PNG generation
     scale: 1                // scaling factor to apply during conversion
 
 Similarly, mathjax-node's `result` object is extended with new keys `png` (containing the resulting data-uri string) and `pngWidth` (PNG width in pixel).

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,8 +45,10 @@ var svg2png = require('svg2png');
 //
 
 exports.typeset = function(data, callback) {
+    var svg = data.svg;
     if (data.png) data.svg = true;
     mathjax.typeset(data, function(result) {
+        data.svg = svg;
         if (result.error) callback(result);
         if (data.png) convert(result, data, callback);
     });

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,7 +34,7 @@ var svg2png = require('svg2png');
 // input `data` extends mathjax-node input `data`.
 // Additional values are:
 //
-// png: false         // enable PNG generation
+// png: true         // enable PNG generation
 // scale: 1,         // scaling factor to apply during conversion
 
 // `result` data extends the mathjax-node `result` data.

--- a/lib/main.js
+++ b/lib/main.js
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-var mathjax = require("mathjax-node");
+var mathjax = require('mathjax-node');
 var svg2png = require('svg2png');
 
 // input `data` extends mathjax-node input `data`.
@@ -56,7 +56,7 @@ exports.typeset = function(data, callback) {
 };
 
 var convert = function(result, data, callback) {
-    var sourceBuffer = new Buffer(result.svg, "utf-8");
+    var sourceBuffer = new Buffer(result.svg, 'utf-8');
     var scale = data.scale || 1;
     // NOTE magic constant, vaguely matches ~16pt Times
     const EXTOPX = data.ex || 6;
@@ -64,7 +64,7 @@ var convert = function(result, data, callback) {
     var returnBuffer = svg2png.sync(sourceBuffer, {
         width: result.pngWidth
     });
-    result.png = "data:image/png;base64," + returnBuffer.toString('base64');
+    result.png = 'data:image/png;base64,' + returnBuffer.toString('base64');
     callback(result);
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,6 +51,7 @@ exports.typeset = function(data, callback) {
         data.svg = svg;
         if (result.error) callback(result);
         if (data.png) convert(result, data, callback);
+        else callback(result);
     });
 };
 

--- a/test/png.js
+++ b/test/png.js
@@ -1,10 +1,11 @@
 var tape = require('tape');
 var typeset = require("../lib/main.js").typeset;
 tape('basic test: check PNG generation', function(t) {
-    t.plan(2);
-    var options = {math: '\\sin(x)', format:'TeX', png:true};
+    t.plan(3);
+    var options = {math: '\\sin(x)', format:'TeX', svg: false, png:true};
     typeset(options, function (result) {
         t.equal(result.png.indexOf("data:image/png;base64"), 0, 'PNG data-uri header');
         t.ok(result.png.length > 100, 'PNG data length');
+        t.equal(options.svg, false, 'Invariant options');
     });
 });

--- a/test/svg.js
+++ b/test/svg.js
@@ -1,0 +1,12 @@
+var tape = require('tape');
+var typeset = require("../lib/main.js").typeset;
+tape('basic test: check svg generation', function(t) {
+    t.plan(4);
+    var options = {math: '\\cos(x)', format:'TeX', svg: true};
+    typeset(options, function (result) {
+        t.ok(true, 'Callback was invoked');
+        t.equal(typeof result.svg, 'string', 'Content was generated')
+        t.ok(result.svg.match(/^<svg .*>/i), 'Content is SVG format');
+        t.equal(options.svg, true, 'Invariant options');
+    });
+});


### PR DESCRIPTION
Hi,

tried using `mathjax-node-svg2png` with `mathjax-server`, but for some reason I never got any PNG output, because the server was looking at `param.svg` to determine output format, but this was always transformed to `true` as soon as `params.png` parameter was set.

This should be fixed with 7745f6e
Additionally I fixed a typo in the readme with 6688057